### PR TITLE
Fix: Convert Textareas to Text Inputs and Improve UI

### DIFF
--- a/app/Filament/Resources/ItemResource/Pages/ModalQrBarang.php
+++ b/app/Filament/Resources/ItemResource/Pages/ModalQrBarang.php
@@ -157,16 +157,19 @@ class ModalQrBarang extends Page implements Tables\Contracts\HasTable, Infolists
         return [
             Actions\Action::make('create')
                 ->label('New Item')
+                ->visible(fn () => auth()->user()->hasRole('admin'))
                 ->url(ItemResource::getUrl('create')),
 
             Actions\Action::make('edit')
                 ->label('Edit')
                 ->icon('heroicon-o-pencil-square')
+                ->visible(fn () => auth()->user()->hasRole('admin'))
                 ->url(ItemResource::getUrl('edit', ['record' => $this->itemId])),
 
             Actions\Action::make('delete')
                 ->label('Delete')
                 ->icon('heroicon-o-trash')
+                ->visible(fn () => auth()->user()->hasRole('admin'))
                 ->color('danger')
                 ->requiresConfirmation()
                 ->action(function () {

--- a/app/Filament/Resources/LoanResource.php
+++ b/app/Filament/Resources/LoanResource.php
@@ -16,6 +16,7 @@ use Filament\Resources\Resource;
 use Filament\Tables;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
+use Filament\Forms\Components\Textarea;
 use Filament\Facades\Filament;
 use Filament\Notifications\Notification;
 use Illuminate\Database\Eloquent\SoftDeletingScope;
@@ -74,13 +75,12 @@ class LoanResource extends Resource
                     ->label('Tanggal Peminjaman')
                     ->required(),
 
-                Forms\Components\TextInput::make('alasan')
+                Forms\Components\Textarea::make('alasan')
                     ->label('Alasan Peminjaman')
                     ->required()
                     ->dehydrateStateUsing(fn ($state) => strip_tags($state)) // menghapus tag html
                     ->rows(3)
-                    ->columnSpanFull()
-                    ->textarea(),
+                    ->columnSpanFull(),
 
                 Forms\Components\Select::make('status')
                     ->options([

--- a/app/Filament/Resources/LoanResource.php
+++ b/app/Filament/Resources/LoanResource.php
@@ -74,12 +74,13 @@ class LoanResource extends Resource
                     ->label('Tanggal Peminjaman')
                     ->required(),
 
-                Forms\Components\TextArea::make('alasan')
+                Forms\Components\TextInput::make('alasan')
                     ->label('Alasan Peminjaman')
                     ->required()
                     ->dehydrateStateUsing(fn ($state) => strip_tags($state)) // menghapus tag html
                     ->rows(3)
-                    ->columnSpanFull(),
+                    ->columnSpanFull()
+                    ->textarea(),
 
                 Forms\Components\Select::make('status')
                     ->options([

--- a/app/Filament/Resources/LoanResource/Pages/AcceptLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/AcceptLoan.php
@@ -6,6 +6,7 @@ use App\Models\Loan;
 use App\Filament\Resources\LoanResource;
 use Filament\Resources\Pages\Page;
 use Filament\Forms;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\FileUpload;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
@@ -36,11 +37,10 @@ class AcceptLoan extends Page
                 ->columnSpanFull()
                 ->required(),
 
-            Forms\Components\TextInput::make('alasan_admin')
+            Forms\Components\Textarea::make('alasan_admin')
                 ->label('Alasan Penyetujuan')
                 ->dehydrateStateUsing(fn ($state) => strip_tags($state))
-                ->placeholder('Tulis alasan...')
-                ->textarea(),
+                ->placeholder('Tulis alasan...'),
         ])
         ->statepath('formData');
     }

--- a/app/Filament/Resources/LoanResource/Pages/AcceptLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/AcceptLoan.php
@@ -6,7 +6,6 @@ use App\Models\Loan;
 use App\Filament\Resources\LoanResource;
 use Filament\Resources\Pages\Page;
 use Filament\Forms;
-use Filament\Forms\Components\TextArea;
 use Filament\Forms\Components\FileUpload;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
@@ -37,10 +36,11 @@ class AcceptLoan extends Page
                 ->columnSpanFull()
                 ->required(),
 
-            Forms\Components\TextArea::make('alasan_admin')
+            Forms\Components\TextInput::make('alasan_admin')
                 ->label('Alasan Penyetujuan')
                 ->dehydrateStateUsing(fn ($state) => strip_tags($state))
-                ->placeholder('Tulis alasan...'),
+                ->placeholder('Tulis alasan...')
+                ->textarea(),
         ])
         ->statepath('formData');
     }

--- a/app/Filament/Resources/LoanResource/Pages/EditLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/EditLoan.php
@@ -41,11 +41,12 @@ class EditLoan extends EditRecord
                 Forms\Components\DatePicker::make('loan_date')
                     ->label('Tanggal Pinjam'),
 
-                Forms\Components\TextArea::make('alasan')
+                Forms\Components\TextInput::make('alasan')
                     ->label('Alasan Peminjaman')
                     ->required()
                     ->rows(3)
-                    ->columnSpanFull(),
+                    ->columnSpanFull()
+                    ->textarea(),
             ]);
     }
 

--- a/app/Filament/Resources/LoanResource/Pages/EditLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/EditLoan.php
@@ -5,6 +5,7 @@ namespace App\Filament\Resources\LoanResource\Pages;
 use App\Filament\Resources\LoanResource;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Filament\Forms\Components\Textarea;
 use Filament\Forms;
 use App\Models\Item;
 
@@ -41,12 +42,11 @@ class EditLoan extends EditRecord
                 Forms\Components\DatePicker::make('loan_date')
                     ->label('Tanggal Pinjam'),
 
-                Forms\Components\TextInput::make('alasan')
+                Forms\Components\Textarea::make('alasan')
                     ->label('Alasan Peminjaman')
                     ->required()
                     ->rows(3)
-                    ->columnSpanFull()
-                    ->textarea(),
+                    ->columnSpanFull(),
             ]);
     }
 

--- a/app/Filament/Resources/LoanResource/Pages/RejectLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/RejectLoan.php
@@ -6,7 +6,6 @@ use App\Models\Loan;
 use App\Filament\Resources\LoanResource;
 use Filament\Resources\Pages\Page;
 use Filament\Forms;
-use Filament\Forms\Components\TextArea;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
 
@@ -25,10 +24,11 @@ class RejectLoan extends Page
     {
         return $form
             ->schema([
-                Forms\Components\TextArea::make('alasan_admin')
+                Forms\Components\TextInput::make('alasan_admin')
                     ->label('Alasan Penolakan')
                     ->dehydrateStateUsing(fn ($state) => strip_tags($state))
                     ->placeholder('Tulis alasan...')
+                    ->textarea()
                     ->required(),
             ]);
     }

--- a/app/Filament/Resources/LoanResource/Pages/RejectLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/RejectLoan.php
@@ -6,6 +6,7 @@ use App\Models\Loan;
 use App\Filament\Resources\LoanResource;
 use Filament\Resources\Pages\Page;
 use Filament\Forms;
+use Filament\Forms\Components\Textarea;
 use Filament\Notifications\Notification;
 use Filament\Pages\Actions\Action;
 
@@ -24,11 +25,10 @@ class RejectLoan extends Page
     {
         return $form
             ->schema([
-                Forms\Components\TextInput::make('alasan_admin')
+                Forms\Components\Textarea::make('alasan_admin')
                     ->label('Alasan Penolakan')
                     ->dehydrateStateUsing(fn ($state) => strip_tags($state))
                     ->placeholder('Tulis alasan...')
-                    ->textarea()
                     ->required(),
             ]);
     }

--- a/app/Filament/Resources/LoanResource/Pages/ReturnLoan.php
+++ b/app/Filament/Resources/LoanResource/Pages/ReturnLoan.php
@@ -11,7 +11,6 @@ use Filament\Resources\Pages\Page;
 // use Filament\Resources\Pages\PageRecord;
 use Filament\Resources\Pages\EditRecord;
 use Filament\Forms\Components\DatePicker;
-use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\Select;
 use Filament\Notifications\Notification;
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -15,5 +15,5 @@ use App\Models\Item;
 */
 
 Route::get('/', function () {
-    return view('welcome');
+    return redirect()->route('filament.admin.auth.login');
 });


### PR DESCRIPTION
This pull request addresses several issues related to form fields and user interface (UI) visibility. The primary changes involve replacing various textarea fields with text inputs. This change was implemented for the loan reason, alasan, and alasan_admin fields to ensure consistency and improve the user experience for single-line inputs.

Additionally, this PR includes a fix to the visibility of the "create, edit, and delete item" buttons for employees, ensuring the appropriate UI elements are displayed. A redirect to the login page was also added, likely to handle authentication-related issues.

The numerous commits titled "memperbaiki text area" and the repeated change of alasan_admin and alasan fields indicate an effort to systematically address and resolve these UI inconsistencies.

This PR aims to:

Improve Form Usability: By changing multi-line textarea fields to single-line text inputs where appropriate.

Enhance UI Visibility: By fixing the display of item management buttons for employees.

Resolve Redirect Issues: By ensuring users are properly redirected to the login page.